### PR TITLE
Patch support for overrides & git_override support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
@@ -26,6 +26,7 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
   @Override
   public RepoSpec getRepoSpec(String repoName) {
     return IndexRegistry.getRepoSpecForArchive(
-        repoName, getUrls(), getPatches(), ImmutableMap.of(), getIntegrity(), getStripPrefix(), getPatchStrip());
+        repoName, getUrls(), getPatches(), ImmutableMap.of(), getIntegrity(), getStripPrefix(),
+        getPatchStrip());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -44,6 +44,7 @@ java_library(
         "ArchiveOverride.java",
         "DiscoveryFunction.java",
         "DiscoveryValue.java",
+        "GitOverride.java",
         "LocalPathOverride.java",
         "Module.java",
         "ModuleFileFunction.java",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/GitOverride.java
@@ -1,0 +1,33 @@
+package com.google.devtools.build.lib.bazel.bzlmod;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.bzlmod.repo.RepoSpec;
+
+@AutoValue
+public abstract class GitOverride implements NonRegistryOverride {
+
+  private static final String GIT_REPOSITORY_RULE_CLASS =
+      "@bazel_tools//tools/build_defs/repo:git.bzl%git_repository";
+
+  public static GitOverride create(String remote, String commit, ImmutableList<String> patches, int patchStrip) {
+    return new AutoValue_GitOverride(remote, commit, patches, patchStrip);
+  }
+
+  public abstract String getRemote();
+  public abstract String getCommit();
+  public abstract ImmutableList<String> getPatches();
+  public abstract int getPatchStrip();
+
+  @Override
+  public RepoSpec getRepoSpec(String repoName) {
+    ImmutableMap.Builder<String, Object> attrBuilder = ImmutableMap.builder();
+    attrBuilder.put("name", repoName)
+        .put("remote", getRemote())
+        .put("commit", getCommit())
+        .put("patches", getPatches())
+        .put("patch_args", ImmutableList.of("-p" + getPatchStrip()));
+    return new RepoSpec(GIT_REPOSITORY_RULE_CLASS, attrBuilder.build());
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -57,8 +57,11 @@ public class ModuleFileGlobals implements ModuleFileGlobalsApi<ModuleFileFunctio
   }
 
   @Override
-  public StarlarkOverrideApi singleVersionOverride(String version, String registry) {
-    return SingleVersionOverride.create(version, registry);
+  public StarlarkOverrideApi singleVersionOverride(String version, String registry,
+      Iterable<?> patches, StarlarkInt patchStrip) throws EvalException {
+    return SingleVersionOverride.create(version, registry,
+        ImmutableList.copyOf((Iterable<String>) patches),
+        patchStrip.toInt("single_version_override.patch_strip"));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -14,6 +14,7 @@ import net.starlark.java.eval.Starlark;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import net.starlark.java.eval.StarlarkInt;
 
 public class ModuleFileGlobals implements ModuleFileGlobalsApi<ModuleFileFunctionException> {
 
@@ -62,7 +63,7 @@ public class ModuleFileGlobals implements ModuleFileGlobalsApi<ModuleFileFunctio
 
   @Override
   public StarlarkOverrideApi archiveOverride(Object urls, String integrity,
-      String stripPrefix) {
+      String stripPrefix, Iterable<?> patches, StarlarkInt patchStrip) throws EvalException {
     ImmutableList.Builder<String> urlList = new ImmutableList.Builder<>();
     if (urls instanceof String) {
       urlList.add((String) urls);
@@ -71,8 +72,17 @@ public class ModuleFileGlobals implements ModuleFileGlobalsApi<ModuleFileFunctio
         urlList.add(urlString);
       }
     }
-    // TODO: add patch file support here as well
-    return ArchiveOverride.create(urlList.build(), ImmutableList.of(), integrity, stripPrefix, 0);
+    return ArchiveOverride.create(
+        urlList.build(), ImmutableList.copyOf((Iterable<String>) patches), integrity, stripPrefix,
+        patchStrip.toInt("archive_override.patch_strip"));
+  }
+
+  @Override
+  public StarlarkOverrideApi gitOverride(String remote, String commit, Iterable<?> patches,
+      StarlarkInt patchStrip) throws EvalException {
+    return GitOverride.create(
+        remote, commit, ImmutableList.copyOf((Iterable<String>) patches),
+        patchStrip.toInt("git_override.patch_strip"));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionFunction.java
@@ -59,7 +59,8 @@ public class SelectionFunction implements SkyFunction {
     collectDeps(ModuleKey.create(discovery.getRootModuleName(), ""), newDepGraph, referenced);
     ImmutableMap<ModuleKey, Module> finalDepGraph =
         ImmutableMap.copyOf(Maps.filterKeys(newDepGraph, referenced::contains));
-    return SelectionValue.create(discovery.getRootModuleName(), finalDepGraph);
+    return SelectionValue.create(
+        discovery.getRootModuleName(), finalDepGraph, discovery.getOverrides());
   }
 
   private void collectDeps(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SelectionValue.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import com.google.devtools.build.lib.starlarkbuildapi.repository.StarlarkOverrideApi;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 
@@ -14,12 +15,15 @@ public abstract class SelectionValue implements SkyValue {
   public static final SkyKey KEY = () -> SkyFunctions.SELECTION;
 
   public static SelectionValue create(String rootModuleName,
-      ImmutableMap<ModuleKey, Module> depGraph) {
-    return new AutoValue_SelectionValue(rootModuleName, depGraph);
+      ImmutableMap<ModuleKey, Module> depGraph,
+      ImmutableMap<String, StarlarkOverrideApi> overrides) {
+    return new AutoValue_SelectionValue(rootModuleName, depGraph, overrides);
   }
 
   public abstract String getRootModuleName();
 
   public abstract ImmutableMap<ModuleKey, Module> getDepGraph();
+
+  public abstract ImmutableMap<String, StarlarkOverrideApi> getOverrides();
 
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/SingleVersionOverride.java
@@ -1,16 +1,22 @@
 package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 @AutoValue
 public abstract class SingleVersionOverride implements RegistryOverride {
 
-  public static SingleVersionOverride create(String version, String registry) {
-    return new AutoValue_SingleVersionOverride(version, registry);
+  public static SingleVersionOverride create(String version, String registry,
+      ImmutableList<String> patches, int patchStrip) {
+    return new AutoValue_SingleVersionOverride(version, registry, patches, patchStrip);
   }
 
   public abstract String getVersion();
 
   @Override
   public abstract String getRegistry();
+
+  public abstract ImmutableList<String> getPatches();
+
+  public abstract int getPatchStrip();
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/ModuleFileGlobalsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/ModuleFileGlobalsApi.java
@@ -21,6 +21,7 @@ import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkInt;
 
 /**
  * A collection of global Starlark build API functions that apply to WORKSPACE files.
@@ -48,7 +49,8 @@ public interface ModuleFileGlobalsApi<ModuleFileFunctionExceptionT extends Excep
           //   & platforms
       },
       extraKeywords = @Param(name = "kwargs"))
-  void module(String name, String version, Dict<String, Object> kwargs) throws EvalException, InterruptedException;
+  void module(String name, String version, Dict<String, Object> kwargs)
+      throws EvalException, InterruptedException;
 
   @StarlarkMethod(
       name = "bazel_dep",
@@ -137,10 +139,53 @@ public interface ModuleFileGlobalsApi<ModuleFileFunctionExceptionT extends Excep
               named = true,
               positional = false,
               defaultValue = "''"),
-          // TODO: patch_files, patch_strip
+          @Param(
+              name = "patches",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "[]"),
+          @Param(
+              name = "patch_strip",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "0"),
       })
-  StarlarkOverrideApi archiveOverride(Object urls, String integrity, String stripPrefix)
-      throws ModuleFileFunctionExceptionT;
+  StarlarkOverrideApi archiveOverride(Object urls, String integrity, String stripPrefix,
+      Iterable<?> patches, StarlarkInt patchStrip)
+      throws EvalException, ModuleFileFunctionExceptionT;
+
+  @StarlarkMethod(
+      name = "git_override",
+      doc = "TODO",
+      parameters = {
+          @Param(
+              name = "remote",
+              doc = "TODO",
+              named = true,
+              positional = false),
+          @Param(
+              name = "commit",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "''"),
+          @Param(
+              name = "patches",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "[]"),
+          @Param(
+              name = "patch_strip",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "0"),
+      })
+  StarlarkOverrideApi gitOverride(String remote, String commit, Iterable<?> patches,
+      StarlarkInt patchStrip) throws EvalException, ModuleFileFunctionExceptionT;
 
   @StarlarkMethod(
       name = "local_path_override",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/ModuleFileGlobalsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/ModuleFileGlobalsApi.java
@@ -110,9 +110,21 @@ public interface ModuleFileGlobalsApi<ModuleFileFunctionExceptionT extends Excep
               named = true,
               positional = false,
               defaultValue = "''"),
-          // TODO: patch_files, patch_strip
+          @Param(
+              name = "patches",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "[]"),
+          @Param(
+              name = "patch_strip",
+              doc = "TODO",
+              named = true,
+              positional = false,
+              defaultValue = "0"),
       })
-  StarlarkOverrideApi singleVersionOverride(String version, String registry);
+  StarlarkOverrideApi singleVersionOverride(String version, String registry, Iterable<?> patches,
+      StarlarkInt patchStrip) throws EvalException;
 
   @StarlarkMethod(
       name = "archive_override",


### PR DESCRIPTION
Added git_override support (uses git_repository).

Now archive_override, git_override, and single_version_override all support patches.