### PR TITLE
Apply remote patches and local patches separately

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ArchiveOverride.java
@@ -26,7 +26,13 @@ public abstract class ArchiveOverride implements NonRegistryOverride {
   @Override
   public RepoSpec getRepoSpec(String repoName) {
     return IndexRegistry.getRepoSpecForArchive(
-        repoName, getUrls(), getPatches(), ImmutableMap.of(), getIntegrity(), getStripPrefix(),
-        getPatchStrip());
+        /* repoName= */ repoName,
+        /* urls= */ getUrls(),
+        /* integrity= */ getIntegrity(),
+        /* stripPrefix= */ getStripPrefix(),
+        /* patches= */ getPatches(),
+        /* patchStrip= */ getPatchStrip(),
+        /* remotePatches= */ ImmutableMap.of(),
+        /* remotePatchStrip= */ 0);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -22,8 +22,8 @@ java_library(
 java_library(
     name = "registry",
     srcs = [
-        "Registry.java",
         "IndexRegistry.java",
+        "Registry.java",
         "RegistryFactory.java",
         "RegistryFactoryImpl.java",
     ],
@@ -33,6 +33,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/net/starlark/java/eval",
         "//third_party:gson",
         "//third_party:guava",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -9,6 +9,9 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import net.starlark.java.eval.StarlarkInt;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -136,26 +139,29 @@ public class IndexRegistry implements Registry {
       }
     }
     return getRepoSpecForArchive(
-        repoName,
-        urls.build(),
-        ImmutableList.of(),
-        remotePatches.build(),
-        sourceJson.get().integrity,
-        Strings.nullToEmpty(sourceJson.get().stripPrefix),
-        sourceJson.get().patchStrip);
+        /* repoName= */ repoName,
+        /* urls= */ urls.build(),
+        /* integrity= */ sourceJson.get().integrity,
+        /* stripPrefix= */ Strings.nullToEmpty(sourceJson.get().stripPrefix),
+        /* patches= */ ImmutableList.of(),
+        /* patchStrip= */ 0,
+        /* remotePatches= */ remotePatches.build(),
+        /* remotePatchStrip= */ sourceJson.get().patchStrip);
   }
 
   public static RepoSpec getRepoSpecForArchive(String repoName, ImmutableList<String> urls,
-      ImmutableList<String> patches, ImmutableMap<String, String> remotePatches, String integrity,
-      String stripPrefix, int patchStrip) {
+      String integrity, String stripPrefix,
+      ImmutableList<String> patches, int patchStrip,
+      ImmutableMap<String, String> remotePatches, int remotePatchStrip) {
     ImmutableMap.Builder<String, Object> attrBuilder = ImmutableMap.builder();
     attrBuilder.put("name", repoName)
         .put("urls", urls)
         .put("integrity", integrity)
+        .put("strip_prefix", stripPrefix)
         .put("patches", patches)
-        .put("remote_patches", remotePatches)
         .put("patch_args", ImmutableList.of("-p" + patchStrip))
-        .put("strip_prefix", stripPrefix);
+        .put("remote_patches", remotePatches)
+        .put("remote_patch_strip", StarlarkInt.of(remotePatchStrip));
     return new RepoSpec(HTTP_ARCHIVE_RULE_CLASS, attrBuilder.build());
   }
 }

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -292,11 +292,12 @@ following: `"zip"`, `"jar"`, `"war"`, `"tar"`, `"tar.gz"`, `"tgz"`,
         default = {},
         doc =
             "A list of URLs of patch files and the corresponding integrity values that are to be applied as patches after " +
-            "extracting the archive and applied patch files from the `patches` attribute. " +
-            "By default, it uses the Bazel-native patch implementation " +
-            "which doesn't support fuzz match and binary patch, but Bazel will fall back to use " +
-            "patch command line tool if `patch_tool` attribute is specified or there are " +
-            "arguments other than `-p` in `patch_args` attribute.",
+            "extracting the archive and before applying patch files from the `patches` attribute. " +
+            "It uses the Bazel-native patch implementation, you can specify the patch strip number with `remote_patch_strip`",
+    ),
+    "remote_patch_strip": attr.int(
+        default = 0,
+        doc = "The number of leading slashes to be stripped from the file name in the remote patches."
     ),
     "patch_tool": attr.string(
         default = "",
@@ -312,7 +313,7 @@ following: `"zip"`, `"jar"`, `"war"`, `"tar"`, `"tar.gz"`, `"tgz"`,
             "If arguments other than -p are specified, Bazel will fall back to use patch " +
             "command line tool instead of the Bazel-native patch implementation. When falling " +
             "back to patch command line tool and patch_tool attribute is not specified, " +
-            "`patch` will be used.",
+            "`patch` will be used. This only affects patch files in the `patches` attribute.",
     ),
     "patch_cmds": attr.string_list(
         default = [],


### PR DESCRIPTION
`http_archive` now supports the `remote_patch_strip` attribute.

Remote patches in Bazel registries are applied with `remote_patches` and
`remote_patch_strip`, local patches in override_dep are applied with
`patches` and `patch_args`.